### PR TITLE
Adding an option for defining an alternate image location

### DIFF
--- a/lib/css_img_2_data_uri.js
+++ b/lib/css_img_2_data_uri.js
@@ -12,7 +12,7 @@ desc;
  * @return {String|null} If no match found will return nuil, otherwise the
  * image path.
  */
-function getImagePath(line, filePath) {
+function getImagePath(line, filePath, altImgSource) {
 	var regEx = new RegExp(urlRegex, 'g'),
 		output = [],
 		m;
@@ -21,7 +21,8 @@ m = regEx.exec(line);
 while (m) {
 	output.push({
 		match: m[1],
-		path: path.dirname(filePath) + '/' + m[1]
+		path: path.dirname(filePath) + '/' + m[1],
+		altPath: path.dirname(altImgSource) + '/' + m[1]
 	});
 	m = regEx.exec(line);
 }
@@ -38,13 +39,18 @@ return output.length ? output : null;
 	 * @async
 	 */
 function getMD5ForImage(path, callback) {
-	fs.readFile(path, function (err, data) {
+	fs.readFile(path.path, function (err, data) {
 
 		if (err) {
-			throw err;
+			fs.readFile(path.altPath, function (err, data) {
+				if (err) {
+					throw err;
+				}
+				callback(data.toString('base64'));
+			});
+		} else {
+			callback(data.toString('base64'));
 		}
-
-		callback(data.toString('base64'));
 	});
 }
 
@@ -74,15 +80,15 @@ function checkFile(file, cb) {
 	});
 }
 
-function processLine(line, filePath, cb) {
+function processLine(line, filePath, altImgSource, cb) {
 
 	if (line.indexOf('url(') > -1 && line.indexOf('no-base64') === -1) {
-		var imagePath = getImagePath(line, filePath),
+		var imagePath = getImagePath(line, filePath, altImgSource),
 		count = 0;
 
 		if (imagePath && imagePath.length) {
 			imagePath.forEach(function (p) {
-				getMD5ForImage(p.path, function (base64) {
+				getMD5ForImage(p, function (base64) {
 					p.base64 = base64;
 					p.mime = mime.lookup(p.path);
 					count += 1;
@@ -105,7 +111,7 @@ function processLine(line, filePath, cb) {
 	}
 }
 
-function convertPathsToDataUri(data, filePath, cb) {
+function convertPathsToDataUri(data, filePath, altImgSource, cb) {
 	var lines = data.toString('utf-8').split('\n'),
 	outputLines = [],
 	processedLines = 0,
@@ -121,7 +127,7 @@ function convertPathsToDataUri(data, filePath, cb) {
 	}
 
 	lines.forEach(function (line, index) {
-		processLine(line, filePath, function (line, imagePath) {
+		processLine(line, filePath, altImgSource, function (line, imagePath) {
 			if (imagePath && imagePath.length) {
 				imagePath.forEach(function (i) {
 					if (imagePaths[i] === true) {
@@ -136,8 +142,9 @@ function convertPathsToDataUri(data, filePath, cb) {
 	});
 }
 
-function build(file, cb) {
+function build(file, altImgSource, cb) {
 	var filePath = path.resolve(file);
+	altImgSource = path.resolve(altImgSource);
 
 	if (!filePath) {
 		throw new Error('No file defined');
@@ -149,7 +156,7 @@ function build(file, cb) {
 			if (err) {
 				throw err;
 			}
-			convertPathsToDataUri(data, filePath, cb);
+			convertPathsToDataUri(data, filePath, altImgSource, cb);
 		});
 	});
 }

--- a/tasks/css_img_2_data_uri.js
+++ b/tasks/css_img_2_data_uri.js
@@ -19,12 +19,13 @@ module.exports = function (grunt) {
     grunt.registerTask('css_img_2_data_uri', desc, function () {
         var options = this.options(),
             files = options.files,
+			altImgSource = options.altImgSource,
             filesLen = files.length,
             done = this.async(),
             doneCounter = 0;
 
         files.forEach(function (f) {
-            build(f.src, function (css, duplicates) {
+            build(f.src, altImgSource, function (css, duplicates) {
 
                 if (duplicates.length) {
                     if (options.throwOnDuplicate) {


### PR DESCRIPTION
Adding an option for defining an alternate image location. I ran into a situation, when using the plugin, that I had some css classes referencing images from different projects so the plugin could not find those. I added an option for defining an alternate image location.
